### PR TITLE
Added python26 compatibility.

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -7,12 +7,16 @@ import time
 import json
 import requests
 import argparse
-import subprocess
 
 try:
     from urllib.parse import urlencode
 except ImportError: # pragma: no cover
     from urllib import urlencode
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 version = VERSION = __version__ = '1.1.3'
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from setuptools import setup
+import sys
 
 version = '1.1.3'
 classifiers = ["Development Status :: 4 - Beta",
@@ -26,5 +27,6 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.0.0", "coverage"],
+      install_requires=["requests>=2.0.0", "coverage"] + (["subprocess32"] if sys.version_info[:2] == (2, 6) else []),
+      tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:cli']})

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,11 +1,15 @@
 import os
 import json
 import requests
-import unittest
+import unittest2 as unittest
 import itertools
-import subprocess
 
 import codecov
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 
 class TestUploader(unittest.TestCase):


### PR DESCRIPTION
Main fix was using subprocess32 on 2.6 which backports check_output from
2.7+'s subprocess.

Using unittest2 which backports methods introduced in python2.7's
unittest.
