### PR TITLE
Replace subprocess32 with future

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -19,9 +19,11 @@ try:
 except ImportError:  # pragma: no cover
     from urllib import urlencode
 
-try:
-    import subprocess32 as subprocess
-except ImportError:
+if sys.version_info < (2, 7):
+    from future import standard_library
+    standard_library.install_aliases()
+    import subprocess
+else:
     import subprocess
 
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.0.0", "rollbar", "coverage"] + (["subprocess32"] if sys.version_info[:2] == (2, 6) else []),
+      install_requires=["requests>=2.0.0", "rollbar", "coverage"] + (["future"] if sys.version_info[:2] == (2, 6) else []),
       tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:cli']})


### PR DESCRIPTION
subprocess32 is not actively maintained, requires a compiler
and doesnt have wheels on pypi.python.org.