### PR TITLE
use extra requirements to determine dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.0.0", "coverage"] + (["future"] if sys.version_info[:2] == (2, 6) else []),
+      install_requires=["requests>=2.0.0", "coverage"],
+      extras_require={':python_version=="2.6"': ['future']},
       tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:main']})


### PR DESCRIPTION
When `pip install codecov` is run under a python2.6 evironment the dependecy `future` is not installed. This is due to the fact, that the wheel on pypi is faulty. As stated in https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies the prefered way to define conditional dependencies is to use `extras_require` which will lead to a `metadata.json` file inside the wheel that respects the python version and then installs the `future` library accordingly. 
This is only a problem when the wheel is created under a python 2.7 environment (the py26 requirement is stripped out). 
The PR will fix the behaviour and use the way described in the above link. 
Please update the wheel on PYPI. 