### PR TITLE
Fix handling of different GitLab CI versions

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -439,7 +439,10 @@ def main(*argv, **kwargs):
                               build=os.getenv('CI_BUILD_ID'),
                               slug=os.getenv('CI_BUILD_REPO').split('/', 3)[-1].replace('.git', ''),
                               commit=os.getenv('CI_BUILD_REF')))
-            root = os.getenv('HOME') + '/' + os.getenv('CI_PROJECT_DIR')
+            if os.getenv('CI_PROJECT_DIR').startswith('/'):
+                root = os.getenv('CI_PROJECT_DIR')
+            else:
+                root = os.getenv('HOME') + '/' + os.getenv('CI_PROJECT_DIR')
             write('    Gitlab CI Detected')
 
         # ------


### PR DESCRIPTION
Newer versions of GitLab CI MultiRunner set the CI_PROJECT_DIR environment variable to an absolute path. This change handles both relative and absolute paths correctly.

This PR fixes #54.