### PR TITLE
remove the py26 dependency on python-future

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -13,12 +13,7 @@ try:
 except ImportError:  # pragma: no cover
     from urllib import urlencode
 
-if sys.version_info < (2, 7):
-    from future import standard_library
-    standard_library.install_aliases()
-    import subprocess
-else:
-    import subprocess
+import subprocess
 
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
 try:
@@ -157,9 +152,20 @@ def read(filepath):
         write('    - Ignored: ' + str(e))
 
 
+def check_output(cmd, **popen_args):
+    from subprocess import Popen, PIPE, CalledProcessError
+    process = Popen(cmd, stdout=PIPE, **popen_args)
+    output, _ = process.communicate()
+    if process.returncode:
+        raise CalledProcessError(process.returncode, cmd)
+    else:
+        assert process.returncode == 0
+        return output.decode('utf-8')
+
+
 def try_to_run(cmd):
     try:
-        return subprocess.check_output(cmd, shell=True).decode('utf-8')
+        return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
         write('    Error running `%s`: %s' % (cmd, str(getattr(e, 'output', str(e)))))
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,5 @@ setup(name='codecov',
       include_package_data=True,
       zip_safe=True,
       install_requires=["requests>=2.0.0", "coverage"],
-      extras_require={':python_version=="2.6"': ['future']},
       tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:main']})

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,12 +6,7 @@ from ddt import ddt, data
 from mock import patch, Mock
 import unittest2 as unittest
 
-if sys.version_info < (2, 7):
-    from future import standard_library
-    standard_library.install_aliases()
-    import subprocess
-else:
-    import subprocess
+import subprocess
 
 import codecov
 
@@ -462,7 +457,7 @@ class TestUploader(unittest.TestCase):
         self.fake_report()
         res = self.run_cli()
         self.assertEqual(res['query']['service'], 'drone.io')
-        self.assertEqual(res['query']['commit'], subprocess.check_output("git rev-parse HEAD", shell=True).decode('utf8'))
+        self.assertEqual(res['query']['commit'], codecov.check_output(("git", "rev-parse", "HEAD")))
         self.assertEqual(res['query']['build'], '10')
         self.assertEqual(res['query']['build_url'], 'https://drone.io/github/builds/1')
         self.assertEqual(res['codecov'].token, 'token')

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27, py34
+envlist = py26, py27, py34
 
 [testenv]
 deps =
     -r{toxinidir}/tests/requirements.txt
 commands =
-    py.test tests/
+    py.test tests/test.py


### PR DESCRIPTION
Python-future is problematic because of https://github.com/PythonCharmers/python-future/issues/148

When I add codecov to my python project, my py26 test suite starts failing because of this above bug and my new transitive dependency on python-future.


Testing done:

```
$ tox                                                                                                                                    [34/2331]
GLOB sdist-make: /nail/home/buck/trees/mine/codecov-python/setup.py
py26 inst-nodeps: /nail/home/buck/trees/mine/codecov-python/.tox/dist/codecov-1.6.5.zip
py26 runtests: PYTHONHASHSEED='3117039750'
py26 runtests: commands[0] | py.test tests/test.py
========================================================================================== test session starts ===========================================================================================
platform linux2 -- Python 2.6.7, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /nail/home/buck/trees/mine/codecov-python, inifile:
plugins: cov-2.2.1
collected 68 items

tests/test.py ...................s....s.......................................s...

================================================================================== 65 passed, 3 skipped in 3.66 seconds ==================================================================================
py27 inst-nodeps: /nail/home/buck/trees/mine/codecov-python/.tox/dist/codecov-1.6.5.zip
py27 runtests: PYTHONHASHSEED='3117039750'
py27 runtests: commands[0] | py.test tests/test.py
========================================================================================== test session starts ===========================================================================================
platform linux2 -- Python 2.7.6, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /nail/home/buck/trees/mine/codecov-python, inifile:
plugins: cov-2.2.1
collected 68 items

tests/test.py ...................s....s.......................................s...

================================================================================== 65 passed, 3 skipped in 3.62 seconds ==================================================================================
py34 inst-nodeps: /nail/home/buck/trees/mine/codecov-python/.tox/dist/codecov-1.6.5.zip
py34 runtests: PYTHONHASHSEED='3117039750'
py34 runtests: commands[0] | py.test tests/test.py
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.4.2, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /nail/home/buck/trees/mine/codecov-python, inifile:
plugins: cov-2.2.1
collected 68 items

tests/test.py ...................s....s.......................................s...

================================================================================== 65 passed, 3 skipped in 3.83 seconds ==================================================================================
________________________________________________________________________________________________ summary _________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```