### PR TITLE
FIX: Fix setup.py for 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.0.0", "coverage"],
+      install_requires=["requests>=2.0.0", "coverage", "argparse"],
       tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:main']})


### PR DESCRIPTION
Closes #63.

I guess this must get pulled in during the Travis builds by the test dependencies. I'll try changing Travis in a separate commit to see if it catches the problem on 2.6.