### PR TITLE
Default for -e aka --env is comma-separated $CODECOV_ENV

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -235,7 +235,10 @@ def main(*argv, **kwargs):
     global COLOR
     COLOR = not codecov.no_color
 
-    include_env = set(codecov.env.split(",") or [])
+    include_env = set([])
+    if codecov.env:
+        # Can be none, e.g. codecov -f coverage.xml -e
+        include_env = set(codecov.env.split(","))
 
     write('Codecov v'+version)
     query = dict(commit='', branch='', job='', pr='', build_url='',

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -235,7 +235,7 @@ def main(*argv, **kwargs):
     global COLOR
     COLOR = not codecov.no_color
 
-    include_env = set(codecov.env or [])
+    include_env = set(codecov.env.split(",") or [])
 
     write('Codecov v'+version)
     query = dict(commit='', branch='', job='', pr='', build_url='',


### PR DESCRIPTION
As per #75 / #77 the documentation for the ``-e`` aka ``--env`` switch needs updating, but the codecov-bash help says:

```
    -e ENV       Specify environment variables to be included with this build
                 ex. codecov -e VAR,VAR2
                 (or) set environment variable CODECOV_ENV=VAR,VAR2
```

Trying this fails, as can be shown using the following debug statements:

```
$ git diff
diff --git a/codecov/__init__.py b/codecov/__init__.py
index e93400e..1e8bfa3 100644
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -235,7 +235,10 @@ def main(*argv, **kwargs):
     global COLOR
     COLOR = not codecov.no_color
 
+    print("codecov.env = %r" % codecov.env)
     include_env = set(codecov.env or [])
+    print("include_env = %r" % include_env)
+    sys.exit(1)
 
     write('Codecov v'+version)
     query = dict(commit='', branch='', job='', pr='', build_url='',
```

e.g.

```
$ export CODECOV_ENV="TOX_ENV,CUSTOM_VAR"
$ echo $CODECOV_ENV
TOX_ENV,CUSTOM_VAR
$ python codecov/__init__.py 
codecov.env = 'TOX_ENV,CUSTOM_VAR'
include_env = set(['A', 'C', 'E', 'M', ',', 'O', 'N', 'S', 'R', 'U', 'T', 'V', 'X', '_'])
```

Desired output:

```
$ export CODECOV_ENV="TOX_ENV,CUSTOM_VAR"
$ echo $CODECOV_ENV
TOX_ENV,CUSTOM_VAR
$ python codecov/__init__.py 
codecov.env = 'TOX_ENV,CUSTOM_VAR'
include_env = set('TOX_ENV','CUSTOM_VAR')
```

Proposed fix supplied.