### PR TITLE
Use argparse standard lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ classifiers = ["Development Status :: 5 - Production/Stable",
                "License :: OSI Approved :: Apache Software License",
                "Topic :: Software Development :: Testing"]
 
+if sys.version_info >= (2, 7):
+    install_requires = ["requests>=2.7.9", "coverage"]
+else:
+    install_requires = ["requests>=2.7.9", "coverage", "argparse"]
+
 setup(name='codecov',
       version=version,
       description="Hosted coverage reports for Github, Bitbucket and Gitlab",
@@ -27,6 +32,6 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.7.9", "coverage", "argparse"],
+      install_requires=install_requires,
       tests_require=["unittest2"],
       entry_points={'console_scripts': ['codecov=codecov:main']})


### PR DESCRIPTION
The `argparse` library on pypi has been deprecated and moved to the standard library:

> argparse development happens in the python standard library nowadays, NOT HERE.

Source: [argparse README](https://github.com/ThomasWaldmann/argparse/)

The primary use for the PyPi version of `argparse` is for older versions of Python:
> The PyPi argparse package is mostly for people who want to have argparse on
older Pythons, like < 2.7 or < 3.2 because it was not in stdlib back then.

However, `codecov-python` [does not support](https://github.com/codecov/codecov-python/blob/master/setup.py#L10-L12) these versions.