### PR TITLE
Implement a setup.py command

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -40,7 +40,7 @@ ignored_path = re.compile(r'(/vendor)|'
                           r'(/build/lib)|'
                           r'(/htmlcov)|'
                           r'(/node_modules)|'
-                          r'(/\.yarn-cache)|'                          
+                          r'(/\.yarn-cache)|'
                           r'(\.egg-info)|'
                           r'(/\.git)|'
                           r'(/\.hg)|'
@@ -235,10 +235,11 @@ def main(*argv, **kwargs):
 
     # Parse Arguments
     # ---------------
-    if argv:
-        codecov = parser.parse_args(argv)
-    else:
-        codecov = parser.parse_args()
+
+    try: # (prevent argparse from exiting directly with sys.exit())
+        codecov = parser.parse_args(argv) if argv else parser.parse_args()
+    except SystemExit as system_exit:
+        return system_exit.code
 
     global COLOR
     COLOR = not codecov.no_color
@@ -762,7 +763,7 @@ def main(*argv, **kwargs):
               '  IRC:     #codecov\n'
               '  Gitter:  https://gitter.im/codecov/support\n'
               '  Twitter: @codecov\n')
-        sys.exit(1 if codecov.required else 0)
+        return 1 if codecov.required else 0
 
     else:
         if kwargs.get('debug'):
@@ -770,4 +771,4 @@ def main(*argv, **kwargs):
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/codecov/__main__.py
+++ b/codecov/__main__.py
@@ -1,5 +1,3 @@
 import codecov
 
-
-if __name__ == '__main__':
-    codecov.main()
+codecov.main()

--- a/codecov/__main__.py
+++ b/codecov/__main__.py
@@ -1,3 +1,4 @@
 import codecov
+import sys
 
-codecov.main()
+sys.exit(codecov.main())

--- a/codecov/distcmd.py
+++ b/codecov/distcmd.py
@@ -1,0 +1,163 @@
+import os
+import sys
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
+try:
+    from setuptools import Command
+except ImportError:
+    from distutils.cmd import Command
+
+from distutils.errors import DistutilsArgError
+
+import codecov
+
+
+
+class Codecov(Command):
+
+
+    description = "run my command"
+
+    user_options =  [
+
+        # ======================== Basics ======================== #
+        ('version', None, 'show version'),
+        ('token=', 't', "Private repository token or @filename for file containing the token. Defaults to $CODECOV_TOKEN. Not required for public repositories on Travis-CI, CircleCI and AppVeyor"),
+        ('files=', 'f', 'Target specific files for uploading (comma separated).'),
+        ('flags=', 'F', 'Flag these uploaded files with custom labels (comma separated).'),
+        ('env=', 'e', 'Store environment variables to help distinguish CI builds (comma separated).'),
+        ('required', None, 'If Codecov fails it will exit 1: failing the CI build.'),
+        ('name=', 'n', 'Custom defined name of the upload. Visible in Codecov UI.'),
+
+        # ======================== gcov ======================== #
+        ('gcov-root=', None, "Project root directory when preparing gcov"),
+        ('gcov-glob=', None, "Paths to ignore during gcov gathering"),
+        ('gcov-exec=', None, "gcov executable to run. Defaults to 'gcov'"),
+        ('gcov-args=', None, "extra arguments to pass to gcov"),
+
+        # ======================== Advanced ========================
+        ('disable=', 'X', "Disable features. Accepting **search** to disable crawling through directories, **detect** to disable detecting CI provider, **gcov** disable gcov commands, `pycov` disables running python `coverage xml`, **fix** to disable report adjustments http://bit.ly/1O4eBpt"),
+        ('root=', None, "Project directory. Default: current direcory or provided in CI environment variables"),
+        ('commit=', 'c', "Commit sha, set automatically"),
+        ('branch=', 'b', "Branch name"),
+        ('build=', None, "Specify a custom build number to distinguish ci jobs, provided automatically for supported ci companies"),
+        ('pr=', None, "Specify a custom pr number, provided automatically for supported ci companies"),
+        ('tag=', None, "Git tag"),
+
+        # ======================== Enterprise ======================== #
+        ('slug=', 'r', "Specify repository slug for Enterprise ex. owner/repo"),
+        ('url=', 'u', "Your Codecov endpoint"),
+        ('cacert=', None, "Certificate pem bundle used to verify with your Codecov instance"),
+
+        # ======================== Debugging ======================== #
+        ('dump', None, "Dump collected data and do not send to Codecov"),
+        ('verbose', 'v', "No comfigured yet"),
+        ('no-color', None, "Do not output with color"),
+
+    ]
+
+    def get_list(self, string):
+        for sep in ('\n', ','):
+            if sep in string:
+                return [line.strip() for line in string.split(sep)]
+        return []
+
+    def initialize_options(self):
+
+        parser = ConfigParser()
+        parser.read(['setup.cfg'])
+        section = parser['codecov'] if 'codecov' in parser else parser['DEFAULT']
+
+        # ======================== Basics ======================== #
+        self.version = section.getboolean('version', fallback=False)
+        self.token = section.get('token', fallback=None)
+        if 'files' in section:
+            self.files = self.get_list(section.get('files'))
+        else:
+            self.files = []
+        self.flags = self.get_list(section.get('flags', fallback=''))
+        self.env = self.get_list(section.get('env', fallback=''))
+        self.required = section.getboolean('required', fallback=False)
+        self.name = section.get('name', fallback=None)
+
+        # ======================== gcov ======================== #
+        self.gcov_root = section.get('gcov-root', fallback=None)
+        self.gcov_glob = self.get_list(section.get('gcov-glob', fallback=''))
+        self.gcov_exec = section.get('gcov-exec', fallback=None)
+        self.gcov_args = section.get('gcov-args', fallback=None)
+
+        # ======================== Advanced ======================== #
+        self.disable = []
+        self.root = None
+        self.commit = None
+        self.branch = None
+        self.build = None
+        self.pr = None
+        self.tag = None
+
+        # ======================== Enterprise ======================== #
+        self.slug = None
+        self.url = None
+        self.cacert = None
+
+        # ======================== Debugging ======================== #
+        self.dump = False
+        self.no_color = False
+
+    def finalize_options(self):
+        # Do not check any option since Codecov will check them anyway
+        # plus we don't want to stop the pipeline if codecov is not --required
+        pass
+
+    def run(self):
+
+        if self.version:
+            return codecov.main('--version')
+
+        argv = []
+
+        # ======================== Basics ======================== #
+        if self.token: argv.extend(['--token', self.token])
+        if self.files: argv.extend(['--file'] + self.files)
+        if self.flags: argv.extend(['--flags'] + self.flags)
+        if self.env: argv.extend(['--env'] + self.env)
+        if self.required: argv.append('--required')
+        if self.name: argv.extend(['--name', self.name])
+
+        # ======================== gcov ======================== #
+        if self.gcov_root is not None: argv.extend(['--gcov-root', self.gcov_root])
+        if self.gcov_glob: argv.extend(['--gcov-glob'] + self.gcov_glob)
+        if self.gcov_exec is not None: argv.extend(['--gcov-exec', self.gcov_exec])
+        if self.gcov_args is not None: argv.extend(['--gcov-args', self.gcov_args])
+
+        # ======================== Advanced ======================== #
+        if self.disable: argv.extend(['--disable'] + self.disable)
+        if self.root is not None: argv.extend(['--root', self.root])
+        if self.commit is not None: argv.extend(['--commit', self.commit])
+        if self.branch is not None: argv.extend(['--branch', self.branch])
+        if self.build is not None: argv.extend(['--build', self.build])
+        if self.pr is not None: argv.extend(['--pr', self.pr])
+        if self.tag is not None: argv.extend(['--tag', self.tag])
+
+        # ======================== Enterprise ======================== #
+        if self.slug is not None: argv.extend(['--slug', self.slug])
+        if self.url is not None: argv.extend(['--url', self.url])
+        if self.cacert is not None: argv.extend(['--cacert', self.cacert])
+
+        # ======================== Debugging ======================== #
+        if self.dump: argv.append('--dump')
+        if self.no_color: argv.append('--no-color')
+
+        # Patch sys.argv so that if argv is empty,
+        # codecov does not see the options passed to setup.py
+        sys._argv, sys.argv = sys.argv, []
+        return_code = codecov.main(*argv)
+        sys.argv = sys._argv
+        del sys._argv
+
+        if return_code:
+            sys.exit(return_code)

--- a/codecov/distcmd.py
+++ b/codecov/distcmd.py
@@ -60,10 +60,11 @@ class Codecov(Command):
     ]
 
     def get_list(self, string):
-        for sep in ('\n', ','):
-            if sep in string:
-                return [line.strip() for line in string.split(sep)]
-        return []
+        if string is not None:
+            for sep in ('\n', ','):
+                if sep in string:
+                    return list(map(str.strip, filter(None, string.split(sep))))
+        return list()
 
     def initialize_options(self):
 
@@ -105,6 +106,12 @@ class Codecov(Command):
         self.parse_conf()
         self.parse_args()
 
+        self.files = self.get_list(self.files)
+        self.flags = self.get_list(self.flags)
+        self.env = self.get_list(self.env)
+        self.gcov_glob = self.get_list(self.gcov_glob)
+        self.disable = self.get_list(self.disable)
+
     def parse_args(self):
         argparser = ArgumentParser()
         for _long, short, _ in self.user_options:
@@ -125,22 +132,22 @@ class Codecov(Command):
 
         # ======================== Basics ======================== #
         self.version = section.getboolean('version', fallback=False)
-        if 'files' in section: self.files = self.get_list(section.get('files'))
-        elif 'file' in section: self.files = [section.get('file')]
+        if 'files' in section: self.files = section.get('files')
+        elif 'file' in section: self.files = section.get('file')
         self.token = section.get('token', fallback=None)
-        if 'flags' in section: self.flags = self.get_list(section.get('flags'))
+        if 'flags' in section: self.flags = section.get('flags')
         self.required = section.getboolean('required', fallback=None)
-        if 'env' in section: self.env = self.get_list(section.get('env'))
+        if 'env' in section: self.env = section.get('env')
         self.name = section.get('name', fallback=None)
 
         # ======================== gcov ======================== #
         self.gcov_root = section.get('gcov-root', fallback=None)
-        if 'gcov-glob' in section: self.gcov_glob = self.get_list(section.get('gcov-glob'))
+        if 'gcov-glob' in section: self.gcov_glob = section.get('gcov-glob')
         self.gcov_exec = section.get('gcov-exec', fallback=None)
         self.gcov_args = section.get('gcov-args', fallback=None)
 
         # ======================== Advanced ======================== #
-        if 'disable' in section: self.disable = self.get_list(section.get('disable'))
+        if 'disable' in section: self.disable = section.get('disable')
         self.root = section.get('root', fallback=None)
         self.commit = section.get('commit', fallback=None)
         self.branch = section.get('branch', fallback=None)

--- a/codecov/distcmd.py
+++ b/codecov/distcmd.py
@@ -3,23 +3,23 @@ import sys
 
 try:
     from configparser import ConfigParser
-except ImportError:
+except ImportError: # pragma: no cover
     from ConfigParser import ConfigParser
 
 try:
     from setuptools import Command
-except ImportError:
+except ImportError: # pragma: no cover
     from distutils.cmd import Command
 
 from argparse import ArgumentParser
 from distutils.errors import DistutilsArgError
 
-import codecov
+from codecov import main
 
 
-class Codecov(Command):
+class codecov(Command):
 
-    command_name = "codecov"
+    description = "Upload coverage reports to a codecov server."
 
     user_options =  [
 
@@ -64,6 +64,7 @@ class Codecov(Command):
             for sep in ('\n', ','):
                 if sep in string:
                     return list(map(str.strip, filter(None, string.split(sep))))
+            return [string.strip()]
         return list()
 
     def initialize_options(self):
@@ -168,7 +169,7 @@ class Codecov(Command):
 
         self.ensure_finalized()
         if self.version:
-            return codecov.main('--version')
+            return main('--version')
 
         argv = []
 
@@ -209,7 +210,7 @@ class Codecov(Command):
         # Patch sys.argv so that if argv is empty,
         # codecov does not see the options passed to setup.py
         sys._argv, sys.argv = sys.argv, []
-        return_code = codecov.main(*argv)
+        return_code = main(*argv)
         sys.argv = sys._argv
         del sys._argv
 

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,7 @@ setup(name='codecov',
       zip_safe=True,
       install_requires=install_requires,
       tests_require=["unittest2"],
-      entry_points={'console_scripts': ['codecov=codecov:main']})
+      entry_points={
+          'console_scripts': ['codecov=codecov:main'],
+          'distutils.commands': ['codecov=codecov.distcmd:Codecov']
+      })

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(name='codecov',
       tests_require=["unittest2"],
       entry_points={
           'console_scripts': ['codecov=codecov:main'],
-          'distutils.commands': ['codecov=codecov.distcmd:Codecov']
+          'distutils.commands': ['codecov=codecov.distcmd:codecov']
       })

--- a/tests/test_distcmd.py
+++ b/tests/test_distcmd.py
@@ -89,3 +89,27 @@ class TestDistutilsCommand(unittest.TestCase):
             command = Codecov(dist)
             with self.assertRaises(SystemExit):
                 command.run()
+
+    def test_lists(self):
+        # files and disable in setup.cfg, env in arguments
+
+        setup_cfg = {
+            'disable': 'search, detect, gcov, pycov', # single line list
+            'files': # multi line string
+                '''
+                some random file
+                /some/root/file
+                '''
+        }
+
+        with self.environ(setup_cfg, '--env', 'CI,TRAVIS') as dist:
+            command = Codecov(dist)
+            command.ensure_finalized()
+
+            files = vars(command).get('files')
+            env = vars(command).get('env')
+            disable = vars(command).get('disable')
+
+            self.assertEqual(files, ['some random file', '/some/root/file'])
+            self.assertEqual(env, ['CI', 'TRAVIS'])
+            self.assertEqual(disable, ['search', 'detect', 'gcov', 'pycov'])

--- a/tests/test_distcmd.py
+++ b/tests/test_distcmd.py
@@ -1,0 +1,82 @@
+
+import os
+import tempfile
+import contextlib
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
+try:
+    from setuptools.dist import Distribution
+except ImportError:
+    from distutil.dist import Distribution
+
+from mock import patch
+import unittest2 as unittest
+
+import codecov
+from codecov.distcmd import Codecov
+
+
+class TestDistutilsCommand(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.initdir = os.getcwd()
+        cls.tempdir = tempfile.gettempdir()
+        os.chdir(cls.tempdir)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.initdir)
+
+    @contextlib.contextmanager
+    def environ(self, setup_cfg=None, *args, **variables):
+
+        args = ['codecov'] + list(args)
+
+        if setup_cfg is not None:
+            parser = ConfigParser()
+            parser.add_section('codecov')
+            for k, v in setup_cfg.items():
+                parser.set('codecov', k, str(v))
+            with open('setup.cfg', 'w') as f:
+                parser.write(f)
+
+        yield Distribution({'script_name': 'setup.py',
+                            'script_args': args or ['codecov']})
+
+        #finally:
+        if os.path.isfile('setup.cfg'):
+            os.remove('setup.cfg')
+
+
+    def test_plain(self):
+        # No setup.cfg, no argument, just like running 'codecov' directly
+
+        with self.environ() as dist:
+            command = Codecov(dist)
+            try:
+                command.run()
+            except SystemExit as se:
+                self.assertNotEqual(se, 0)
+                self.fail('Command failed.')
+
+    def test_plain_required(self):
+        # No setup.cfg, --required argument
+
+        with self.environ(None, '--required') as dist:
+            command = Codecov(dist)
+            with self.assertRaises(SystemExit):
+                command.run()
+
+    def test_setupcfg_required(self):
+        # setup.cfg with required=true, no argument
+
+        setup_cfg = {'required': True}
+        with self.environ(setup_cfg) as dist:
+            command = Codecov(dist)
+            with self.assertRaises(SystemExit):
+                command.run()

--- a/tests/test_distcmd.py
+++ b/tests/test_distcmd.py
@@ -1,6 +1,8 @@
 
 import os
 import tempfile
+import shutil
+import subprocess
 import contextlib
 
 try:
@@ -12,6 +14,11 @@ try:
     from setuptools.dist import Distribution
 except ImportError:
     from distutil.dist import Distribution
+
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 
 from mock import patch
 import unittest2 as unittest
@@ -25,12 +32,15 @@ class TestDistutilsCommand(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.initdir = os.getcwd()
-        cls.tempdir = tempfile.gettempdir()
+        cls.tempdir = 'tmp'
+        if not os.path.isdir('tmp'):
+            os.mkdir('tmp')
         os.chdir(cls.tempdir)
 
     @classmethod
     def tearDownClass(cls):
         os.chdir(cls.initdir)
+        shutil.rmtree('tmp')
 
     @contextlib.contextmanager
     def environ(self, setup_cfg=None, *args, **variables):
@@ -51,7 +61,6 @@ class TestDistutilsCommand(unittest.TestCase):
         #finally:
         if os.path.isfile('setup.cfg'):
             os.remove('setup.cfg')
-
 
     def test_plain(self):
         # No setup.cfg, no argument, just like running 'codecov' directly


### PR DESCRIPTION
Hi ! This PR intends to add a `setup.py` for the codecov reporter using the `distutils.commands` entry point. 

### Motives
* Some persons (including me) tend to like using the `setup.py` script as their main development management script, instead of multiplying Makefile commands or scripts, so it would be nice to have a `setup.py` command for codecov too
* Being able to configure codecov from a file (`setup.cfg`) instead of always from the command line would be nice to avoid a *command line flag soup*.

### Implementation
I implemented `codecov.distcmd.codecov`, inheriting from distutils/setuptools `Command`. This command does the following:
* Read the local `setup.cfg` file to get options from the `[codecov]` section
* Read the CLI arguments, overriding values from the configuration file if needed
* For parameters that were given through either of these methods, create a `sys.argv`-like list and pass is to `codecov.main`

### Changes
* I changed `codecov.main` to return an error code instead of exiting directly, and wrapped calls to `codecov.main` in `sys.exit` calls to make sure it still exits when erroring.

### Example
Given the following `setup.cfg` file:
```ini
[codecov]
required = true
disable = search, detect
files = 
    /some/file
    /some/other/file
```
then running the two following commands produces the same result
```shell
codecov --name test --env CI USER HOME
python setup.py codecov --name test --env CI,USER,HOME
```

### Changes

Unfortunately, since `setuptools` arguments cannot take multiple values, I had to resort to the following workaround: for parameters that can take multiple values:
* the `setup.py` can contain multiple lines or comma lists:
    ```ini
    [codecov]
    env = CI, USER, HOME
    env = 
        CI
        USER
        HOME
    ```
* the command line can contain comma lists **without spaces** : `--env CI,USER,HOME`

Since the `file` parameter was not really clear about value multiplicty, the `codecov` section of the `setup.cfg` file can contain either a `file` key (only one file considered) or a `files` key (one file or more considered)

Now test pipelines can be run with a single line : `python setup.py test codecov sdist bdist_wheel upload` !