### PR TITLE
Removed --user to fix travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ after_success:
 ```yaml
 # private repository on Travis CI
 install:
-  - pip install --user codecov
+  - pip install codecov
 # or
   - conda install -c conda-forge codecov
 after_success:


### PR DESCRIPTION
Travis output:
$ pip install --user codecov
Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
Without --user option everything works well :-)