### PR TITLE
Replace `coverage merge` with `coverage combine`

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -660,7 +660,7 @@ def main(*argv, **kwargs):
             if os.path.exists(opj(os.getcwd(), '.coverage')) and not os.path.exists(opj(os.getcwd(), 'coverage.xml')):
                 if glob.glob(opj(os.getcwd(), '.coverage.*')):
                     write('    Mergeing coverage reports')
-                    try_to_run('coverage merge')
+                    try_to_run('coverage combine')
 
                 write('    Generating coverage xml reports for Python')
                 # using `-i` to ignore "No source for code" error


### PR DESCRIPTION
Whether "merge" is an old directive or just one mistaken for "combine", `coverage merge` would always fail as coveragepy does not have that as an actual command.

```
13steinj@13steinj:~/src/sithprof (bugfix/coverage_details)$ coverage merge
Unknown command: 'merge'
Use 'coverage help' for help.
```