### PR TITLE
Encode s3 upload data as utf8

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -719,7 +719,7 @@ def main(*argv, **kwargs):
                         result, upload_url = res[0], res[1]
 
                         write('    Uploading to S3...')
-                        s3 = requests.put(upload_url, data=reports,
+                        s3 = requests.put(upload_url, data=reports.encode('utf-8'),
                                           headers={'Content-Type': 'text/plain',
                                                    'x-amz-acl': 'public-read',
                                                    'x-amz-storage-class': 'REDUCED_REDUNDANCY'})


### PR DESCRIPTION
Resolves #85 

I ran into this issue recently on Circle CI. After making the fix mentioned in the issue comments in a branch on my fork, I was able to successfully upload my test results to codecov.

Before: https://circleci.com/gh/JrGoodle/clowder/97
After: https://circleci.com/gh/JrGoodle/clowder/98

The output before and after the change can be seen at the bottom of the "upload code coverage results" build phase.

If I need to add any tests, just let me know how it would be preferable to test this.