### PR TITLE
coverage combine does not delete .coverage file if present

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -657,11 +657,14 @@ def main(*argv, **kwargs):
             # Call `coverage xml` when .coverage exists
             # -----------------------------------------
             # Ran from current directory
-            if os.path.exists(opj(os.getcwd(), '.coverage')) and not os.path.exists(opj(os.getcwd(), 'coverage.xml')):
-                if glob.glob(opj(os.getcwd(), '.coverage.*')):
-                    write('    Mergeing coverage reports')
-                    try_to_run('coverage combine')
+            if glob.glob(opj(os.getcwd(), '.coverage.*')):
+                write('    Mergeing coverage reports')
+                # The `-a` option is mandatory here. If we 
+                # have a `.coverage` in the current directory, calling 
+                # without the option would delete the previous data
+                try_to_run('coverage combine -a')
 
+            if os.path.exists(opj(os.getcwd(), '.coverage')) and not os.path.exists(opj(os.getcwd(), 'coverage.xml')):
                 write('    Generating coverage xml reports for Python')
                 # using `-i` to ignore "No source for code" error
                 try_to_run('coverage xml -i')


### PR DESCRIPTION
Previously coverage combine was not appending data to a `.coverage` file, if that was present, but was instead deleting it.

Now we call `coverage combine -a` if we find `.coverage*` files. This appends data to an existing `.coverage` file, or otherwise creates a new one.

-----

See https://github.com/spack/spack/issues/6887 for more details on the issue that originated this PR.