### PR TITLE
Output elapsed time with S3 upload

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -739,6 +739,7 @@ def main(*argv, **kwargs):
                             s3 = requests.put(upload_url, data=reports,
                                               headers={'Content-Type': 'text/plain',
                                                        'x-amz-acl': 'public-read'})
+                            write('    Took %s' % s3.elapsed)
                             s3.raise_for_status()
                             assert s3.status_code == 200
                             write('    ' + result)

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -1146,7 +1146,7 @@ def main(*argv, **kwargs):
                         )
                         s3.raise_for_status()
                         assert s3.status_code == 200
-                        write('    Uploading to S3 took %s' % s3.elapsed)
+                        write("    Uploading to S3 took %s" % s3.elapsed)
                         write("    " + result)
                         success = True
 


### PR DESCRIPTION
It seems that it fails with "Forbidden" when it takes longer than 15s,
so this at least helps with debugging that.
The Bash uploader gzips the data file, so it is faster to upload and
does not trigger it with the given data file / internet connection.

    (Pdb++) s3.text
    '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>AccessDenied</Code><Message>Request has expired</Message><Expires>2018-05-19T11:58:04Z</Expires><ServerTime>2018-05-19T11:58:10Z</ServerTime><RequestId>EFE63A2DA8CE9726</RequestId><HostId>LXoeTEXV7h3wN5DICvZg/U6uWIeyOgkJ1JnyEOQCpKNkQtpst4qKhkxuTgPnJeV3uB1jOexYP+s=</HostId></Error>'