### PR TITLE
Include license file and changelog in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CHANGELOG.md
+include LICENSE


### PR DESCRIPTION
Including a license file is very important for legal reasons.  Including the changelog is helpful for users and downstream packagers.