### PR TITLE
CODECOV_* env need to be in tox passenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Just please make sure to pass all the necessary environment variables through:
 
 ```
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_*
+passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
 commands = codecov -e TOXENV
 ```


### PR DESCRIPTION
From https://github.com/tox-dev/tox-travis/issues/106 it became clear that the lack of explicit mention in passenv is confusing to the user. They might think that `CODECOV_*` env vars are automatically passed through. 

As tox only passes through the absolute minimum necessary `CODECOV_*` has to be added to passenv also.