### PR TITLE
Improve error reporting in the "try_run" function and correctly include original command output in the error message

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -181,8 +181,8 @@ def try_to_run(cmd):
     try:
         return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
-        write('    Error running `%s`: output=%s, returncode=%s' % (cmd, str(getattr(e, 'output', str(e))),
-                                                                    e.returncode))
+        write('    Error running `%s`: returncode=%s, output=%s' % (cmd, e.returncode,
+                                                                    str(getattr(e, 'output', str(e)))))
 
 
 def remove_non_ascii(data):

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -181,7 +181,8 @@ def try_to_run(cmd):
     try:
         return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
-        write('    Error running `%s`: output=%s, e=%s' % (cmd, str(getattr(e, 'output', '')), str(e)))
+        write('    Error running `%s`: output=%s, returncode=%s, e=%s' % (cmd,
+            str(getattr(e, 'output', '')), e.returncode, str(e)))
 
 
 def remove_non_ascii(data):

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -171,7 +171,7 @@ def check_output(cmd, **popen_args):
     process = Popen(cmd, stdout=PIPE, **popen_args)
     output, _ = process.communicate()
     if process.returncode:
-        raise CalledProcessError(process.returncode, cmd)
+        raise CalledProcessError(process.returncode, cmd, output)
     else:
         assert process.returncode == 0
         return output.decode('utf-8')
@@ -181,8 +181,8 @@ def try_to_run(cmd):
     try:
         return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
-        write('    Error running `%s`: output=%s, returncode=%s, e=%s' % (cmd,
-            str(getattr(e, 'output', '')), e.returncode, str(e)))
+        write('    Error running `%s`: output=%s, returncode=%s' % (cmd, str(getattr(e, 'output', str(e))),
+                                                                    e.returncode))
 
 
 def remove_non_ascii(data):

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -221,7 +221,7 @@ def check_output(cmd, **popen_args):
 
 def try_to_run(cmd, shell=False, cwd=None):
     try:
-        return check_output(cmd, shell=True, cwd=cwd)
+        return check_output(cmd, shell=shell, cwd=cwd)
     except Exception as e:
         write('    Error running `%s`: returncode=%s, output=%s' % (cmd, e.returncode,
                                                                     str(getattr(e, 'output', str(e)))))

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -223,8 +223,10 @@ def try_to_run(cmd, shell=False, cwd=None):
     try:
         return check_output(cmd, shell=shell, cwd=cwd)
     except Exception as e:
-        write('    Error running `%s`: returncode=%s, output=%s' % (cmd, e.returncode,
-                                                                    str(getattr(e, 'output', str(e)))))
+        write(
+            "    Error running `%s`: returncode=%s, output=%s"
+            % (cmd, e.returncode, str(getattr(e, "output", str(e))))
+        )
         return None
 
 

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -181,7 +181,7 @@ def try_to_run(cmd):
     try:
         return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
-        write('    Error running `%s`: %s' % (cmd, str(getattr(e, 'output', str(e)))))
+        write('    Error running `%s`: output=%s, e=%s' % (cmd, str(getattr(e, 'output', '')), str(e)))
 
 
 def remove_non_ascii(data):


### PR DESCRIPTION
This pull request fixes `check_output` function to correctly include output of the command which ran in the `CalledProcessError` exception which is thrown.

In addition to that, it also includes return (exit) code in the printed error message.

Before this change it was very hard / impossible to debug various codecove command failures because the original command output was not included in the error which is printed to the console.

Before (as you can see, output is always `None` which makes troubleshooting practically impossible):

```bash
      _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
    | |    / _ \ / _  |/ _ \/ __/ _ \ \ / /
    | |___| (_) | (_| |  __/ (_| (_) \ V /
     \_____\___/ \____|\___|\___\___/ \_/
                                    v2.0.15
==> Detecting CI provider
    Travis Detected
==> Preparing upload
==> Processing gcov (disable by -X gcov)
    Executing gcov (find /home/travis/build/StackStorm/st2 -not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**' -type f -name '*.gcno'  -exec gcov -pb  {} +)
==> Collecting reports
    Mergeing coverage reports
    Error running `coverage combine -a`: None
Error: No coverage report found
Tip: See an example python repo: https://github.com/codecov/example-python
Support channels:
  Email:   hello@codecov.io
  IRC:     #codecov
  Gitter:  https://gitter.im/codecov/support
  Twitter: @codecov
```

After (command output is correctly included which makes troubleshooting possible / easier):

```bash
      _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
    | |    / _ \ / _  |/ _ \/ __/ _ \ \ / /
    | |___| (_) | (_| |  __/ (_| (_) \ V /
     \_____\___/ \____|\___|\___\___/ \_/
                                    v2.0.15
==> Detecting CI provider
    Travis Detected
    Fixing merge commit SHA
==> Preparing upload
==> Processing gcov (disable by -X gcov)
    Executing gcov (find /home/travis/build/StackStorm/st2 -not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**' -type f -name '*.gcno'  -exec gcov -pb  {} +)
==> Collecting reports
    Mergeing coverage reports
    Error running `coverage combine -a`: output=Couldn't trace with concurrency=eventlet, the module isn't installed.
, returncode=1
Error: No coverage report found
Tip: See an example python repo: https://github.com/codecov/example-python
Support channels:
  Email:   hello@codecov.io
  IRC:     #codecov
  Gitter:  https://gitter.im/codecov/support
  Twitter: @codecov
```