### PR TITLE
Fix command line quoting for Windows

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -14,10 +14,22 @@ try:
 except ImportError:  # pragma: no cover
     from urllib import urlencode
 
-try:
-    from shlex import quote
-except ImportError: # pragma: no cover
-    from pipes import quote
+quote = None
+if sys.platform == 'win32':  # pragma: no cover
+    try:
+        # https://github.com/python/cpython/blob/3.7/Lib/subprocess.py#L174-L175
+        from subprocess import list2cmdline
+
+        def quote(arg):
+            return list2cmdline([arg])
+    except ImportError:
+        pass
+
+if quote is None:
+    try:
+        from shlex import quote
+    except ImportError:  # pragma: no cover
+        from pipes import quote
 
 import subprocess
 


### PR DESCRIPTION
cc @stevepeak Single quotes do not work in `cmd`, only `powershell`:

https://ci.appveyor.com/project/Datadog/integrations-core/builds/19797599#L705

![capture](https://user-images.githubusercontent.com/9677399/47528822-2bf3bd00-d874-11e8-83ad-7498d39f7129.PNG)

Without `git ls-files` results, path combining does not work cross-platform