### PR TITLE
Include the cacert in the PUT call when uploading to S3

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -1042,6 +1042,7 @@ def main(*argv, **kwargs):
                             s3 = requests.put(
                                 upload_url,
                                 data=reports,
+                                verify=codecov.cacert,
                                 headers={"Content-Type": "text/plain",},
                             )
                             s3.raise_for_status()

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -737,7 +737,6 @@ def main(*argv, **kwargs):
 
                             write('    Uploading to S3...')
                             s3 = requests.put(upload_url, data=reports,
-                                              verify=codecov.cacert,
                                               headers={'Content-Type': 'text/plain',
                                                        'x-amz-acl': 'public-read'})
                             s3.raise_for_status()

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -737,6 +737,7 @@ def main(*argv, **kwargs):
 
                             write('    Uploading to S3...')
                             s3 = requests.put(upload_url, data=reports,
+                                              verify=codecov.cacert,
                                               headers={'Content-Type': 'text/plain',
                                                        'x-amz-acl': 'public-read'})
                             s3.raise_for_status()


### PR DESCRIPTION
This PR adds a `verify=codecov.cacert` argument to the `put()` call when uploading results to S3.  This resolves a problem where a user-specified CACert file is required to successfully connect to the codecov server.  The initial connection to codecov ('Pinging codecov...') includes the CACert and is successful, but the subsequent upload fails because the CACert was not included.