### PR TITLE
Upgrade/pytest 3.6.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-coverage
+coverage>=4.4.0
 ddt
 mock
 pytest>=3.6.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 coverage
 ddt
 mock
-pytest
+pytest>=3.6.0
 pytest-cov
 funcsigs
 requests


### PR DESCRIPTION
Tests are failing on `travis` due to pulling older versions of `pytest` and `coverage`.  This PR pins them to minimums

PTAL @hootener 