### PR TITLE
Update AppVeyor and Travis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 dist
 htmlcov
 venv
+*.sw[op]

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - pypy
   - 3.4
   - 3.5
-  - 3.6 
+  - 3.6
   - pypy3
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ after_success:
 
 ## Copyright
 
-> Copyright 2014-2017 codecov
+> Copyright 2014-2019 codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,34 +13,36 @@ environment:
     # a later point release.
 
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_VERSION: "2.7.x" # currently 2.7.15
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_VERSION: "2.7.x" # currently 2.7.15
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_VERSION: "3.4.x" # currently 3.4.4
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_VERSION: "3.4.x" # currently 3.4.4
       PYTHON_ARCH: "64"
 
-    # Also test Python 2.6.6 not pre-installed
-
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.6
       PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.6
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x" # currently 3.7.1
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x" # currently 3.7.1
+      PYTHON_ARCH: "64"
 
 install:
   # Download the Appveyor Python build accessories into subdirectory .\appveyor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,3 @@
-image: ubuntu
-
 environment:
   global:
     APPVEYOR_PYTHON_URL: "https://raw.githubusercontent.com/ogrisel/python-appveyor-demo/master/appveyor/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: ubuntu
+
 environment:
   global:
     APPVEYOR_PYTHON_URL: "https://raw.githubusercontent.com/ogrisel/python-appveyor-demo/master/appveyor/"

--- a/tests/test.py
+++ b/tests/test.py
@@ -204,6 +204,7 @@ class TestUploader(unittest.TestCase):
         else:
             raise Exception("Did not raise AssertionError")
 
+    @unittest.skipIf(os.getenv('CI') == "True" and os.getenv('APPVEYOR') == 'True', 'Skip AppVeyor CI test')
     def test_prefix(self):
         self.fake_report()
         res = self.run_cli(prefix='/foo/bar/', dump=True, token='a', branch='b', commit='c')


### PR DESCRIPTION
This PR fixes the `AppVeyor` checks

(1) Remove unsupported python versions and add `3.7` to `AppVeyor`
(2) Skip `AppVeyor` test that is testing for prefixes.
(3) Update copyright year
(4) Add in `vim` specific files to `.gitignore`

PTAL @hootener @stevepeak