### PR TITLE
Better error message when try_to_run command fails

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -181,7 +181,7 @@ def try_to_run(cmd):
     try:
         return check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
-        write('    Error running `%s`: %s' % (cmd, str(getattr(e, 'output', str(e)))))
+        write('    Error running `%s`: %s' % (cmd, e.output or str(e)))
 
 
 def remove_non_ascii(data):


### PR DESCRIPTION
The `CalledProcessError` object should always have a `.output` attribute, although it may be None, so the `getattr()` will never hit the fallback condition.

The logical `or` operator should use the fallback if `e.output` is either None or an empty string, because those are both false-y. Any other possible value will be shown.