### PR TITLE
failing on GitLab ≥ 9 (bis)

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -468,12 +468,12 @@ def main(*argv, **kwargs):
         # Gitlab CI
         # ---------
         elif os.getenv('CI_SERVER_NAME', '').startswith("GitLab"):
-            # http://doc.gitlab.com/ci/examples/README.html#environmental-variables
-            # https://gitlab.com/gitlab-org/gitlab-ci-runner/blob/master/lib/build.rb#L96
+            # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+            # https://gitlab.com/gitlab-org/gitlab-ci-runner/blob/master/lib/build.rb
             query.update(dict(service='gitlab',
-                              branch=os.getenv('CI_BUILD_REF_NAME'),
-                              build=os.getenv('CI_BUILD_ID'),
-                              commit=os.getenv('CI_BUILD_REF')))
+                              branch=os.getenv('CI_COMMIT_REF_NAME', os.getenv('CI_BUILD_REF_NAME')),
+                              build=os.getenv('CI_JOB_ID', os.getenv('CI_BUILD_ID')),
+                              commit=os.getenv('CI_COMMIT_SHA', os.getenv('CI_BUILD_REF'))))
             if os.getenv('CI_PROJECT_DIR', '').startswith('/'):
                 root = os.getenv('CI_PROJECT_DIR')
             else:

--- a/tests/test.py
+++ b/tests/test.py
@@ -45,7 +45,9 @@ class TestUploader(unittest.TestCase):
                     "APPVEYOR_BUILD_VERSION", "APPVEYOR_JOB_ID", "APPVEYOR_REPO_NAME", "APPVEYOR_REPO_COMMIT", "WERCKER_GIT_BRANCH",
                     "WERCKER_MAIN_PIPELINE_STARTED", "WERCKER_GIT_OWNER", "WERCKER_GIT_REPOSITORY",
                     "CI_BUILD_REF_NAME", "CI_BUILD_ID", "CI_BUILD_REPO", "CI_PROJECT_DIR", "CI_BUILD_REF", "CI_SERVER_NAME",
+                    "CI_COMMIT_REF_NAME", "CI_JOB_ID", "CI_REPOSITORY_URL", "CI_COMMIT_SHA",
                     "ghprbActualCommit", "ghprbSourceBranch", "ghprbPullId", "WERCKER_GIT_COMMIT", "CHANGE_ID"):
+
             os.environ[key] = ""
 
     def tearDown(self):
@@ -556,12 +558,30 @@ class TestUploader(unittest.TestCase):
         self.assertEqual(res['codecov'].token, 'token')
 
     @unittest.skipUnless(os.getenv('CI_SERVER_NAME', '').startswith("GitLab"), 'Skip GitLab CI test')
-    def test_ci_gitlab(self):
+    def test_ci_gitlab_pre9(self):
         self.set_env(CI_BUILD_REF_NAME='master',
                      CI_BUILD_ID='1399372237',
                      CI_BUILD_REPO='https://gitlab.com/owner/repo.git',
                      CI_SERVER_NAME='GitLab CI',
                      CI_BUILD_REF='d653b934ed59c1a785cc1cc79d08c9aaa4eba73b',
+                     HOME='/',
+                     CI_PROJECT_DIR=os.getcwd().strip('/'),
+                     CODECOV_TOKEN='token')
+        self.fake_report()
+        res = self.run_cli()
+        self.assertEqual(res['query']['service'], 'gitlab')
+        self.assertEqual(res['query']['commit'], 'd653b934ed59c1a785cc1cc79d08c9aaa4eba73b')
+        self.assertEqual(res['query']['build'], '1399372237')
+        self.assertEqual(res['query']['slug'], 'owner/repo')
+        self.assertEqual(res['codecov'].token, 'token')
+
+    @unittest.skipUnless(os.getenv('CI_SERVER_NAME', '').startswith("GitLab"), 'Skip GitLab CI test')
+    def test_ci_gitlab(self):
+        self.set_env(CI_COMMIT_REF_NAME='master',
+                     CI_JOB_ID='1399372237',
+                     CI_REPOSITORY_URL='https://gitlab.com/owner/repo.git',
+                     CI_SERVER_NAME='GitLab CI',
+                     CI_COMMIT_SHA='d653b934ed59c1a785cc1cc79d08c9aaa4eba73b',
                      HOME='/',
                      CI_PROJECT_DIR=os.getcwd().strip('/'),
                      CODECOV_TOKEN='token')


### PR DESCRIPTION
As previously listed in #96 and #97, GitLab 9.0 (released in March 2017) [renamed some variables](https://docs.gitlab.com/ee/ci/variables/deprecated_variables.html) which are still used in `codecov`.

The following patch keep the compatibility with pre-9 releases (GitLab 8 was deprecated around August 2017).

https://about.gitlab.com/blog/categories/releases/