### PR TITLE
Fixed GitLab CI project directory detection on Windows.

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -744,7 +744,7 @@ def main(*argv, **kwargs):
                     commit=os.getenv("CI_BUILD_REF"),
                 )
             )
-            if os.getenv("CI_PROJECT_DIR", "").startswith("/"):
+            if sys.platform == "win32" or os.getenv("CI_PROJECT_DIR", "").startswith("/"):
                 root = os.getenv("CI_PROJECT_DIR")
             else:
                 root = os.getenv("HOME") + "/" + os.getenv("CI_PROJECT_DIR", "")


### PR DESCRIPTION
Windows paths don't start with /