### PR TITLE
Fix broken bitly link in help

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -230,7 +230,7 @@ def main(*argv, **kwargs):
     gcov.add_argument('--gcov-args', default='', help="extra arguments to pass to gcov")
 
     advanced = parser.add_argument_group('======================== Advanced ========================')
-    advanced.add_argument('-X', '--disable', nargs="*", default=[], help="Disable features. Accepting **search** to disable crawling through directories, **detect** to disable detecting CI provider, **gcov** disable gcov commands, `pycov` disables running python `coverage xml`, **fix** to disable report adjustments http://bit.ly/1O4eBpt")
+    advanced.add_argument('-X', '--disable', nargs="*", default=[], help="Disable features. Accepting **search** to disable crawling through directories, **detect** to disable detecting CI provider, **gcov** disable gcov commands, `pycov` disables running python `coverage xml`, **fix** to disable report adjustments https://docs.codecov.io/docs/fixing-reports")
     advanced.add_argument('--root', default=None, help="Project directory. Default: current direcory or provided in CI environment variables")
     advanced.add_argument('--commit', '-c', default=None, help="Commit SHA, set automatically")
     advanced.add_argument('--prefix', '-P', default=None, help="Prefix network paths to help resolve paths: https://github.com/codecov/support/issues/472")


### PR DESCRIPTION
Fix #164 

I assume the broken link which points to https://github.com/codecov/support/wiki/Report-Fixes should be replaced with https://docs.codecov.io/docs/fixing-reports