### PR TITLE
Pin coverage to < 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.7.9", "coverage"],
+      install_requires=["requests>=2.7.9", "coverage<5"],
       entry_points={'console_scripts': ['codecov=codecov:main']},
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       )


### PR DESCRIPTION
Coverage was not pinned in setup.py and recently released a major version. New versions of coverage break codecov reports for python3.6.5 + django2.2 projects:

<img width="1455" alt="Screen Shot 2019-12-18 at 1 10 07 PM" src="https://user-images.githubusercontent.com/4020772/71111600-ce1ce580-2197-11ea-9843-f6920996d16a.png">

Due to the 4th line listed under "Backwards Incompatibilities" [here](https://coverage.readthedocs.io/en/coverage-5.0/whatsnew5x.html):

When constructing a coverage.Coverage object, data_file can be specified as None to prevent writing any data file at all. In previous versions, an explicit data_file=None argument would use the default of “.coverage”. Fixes issue 871.