### PR TITLE
[ADD] support for Windows terminal colored output.

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -8,6 +8,11 @@ import requests
 import argparse
 from time import sleep
 from json import loads
+try:
+    import colorama
+except ImportError:  # pragma: no cover
+    # No color support on Windows
+    print('colorama not found -> No color support on Windows')
 
 try:
     from urllib.parse import urlencode
@@ -208,6 +213,9 @@ def _add_env_if_not_empty(lst, value):
 
 def main(*argv, **kwargs):
     root = os.getcwd()
+    
+    # Initialise Colorama
+    colorama.init()
 
     # Build Parser
     # ------------

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='codecov',
       packages=['codecov'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["requests>=2.7.9", "coverage"],
+      install_requires=["requests>=2.7.9", "coverage", "colorama"],
       entry_points={'console_scripts': ['codecov=codecov:main']},
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       )


### PR DESCRIPTION
Solving #226 .
Now Windows can use colored console prints.