### PR TITLE
Allow the yaml configuration to be located anywhere

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -587,7 +587,7 @@ def main(*argv, **kwargs):
 
         # Detect codecov.yml location
         yaml_location = re.search(
-            r'\.?codecov\.ya?ml$',
+            r'.*\.?codecov\.ya?ml$',
             toc,
             re.M
         )


### PR DESCRIPTION
This PR adds a small fix to the regexp that matches the codecov configuration file. The goal is to allow developers to locate the file anywhere in their repository, for example `.config/codecov.yml`.