### PR TITLE
Update makefile so deploy works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 deploy:
-	git tag -a v$(shell python -c "import codecov;print codecov.version;") -m ""
-	git push origin v$(shell python -c "import codecov;print codecov.version;")
-	python setup.py sdist bdist_wheel upload
+	git tag -a v$(python -c 'import codecov;print(codecov.version)') -m ""
+	git push origin v$(python -c 'import codecov;print(codecov.version)')
+	python setup.py sdist bdist_wheel
+	python -m twine upload dist/*
 
 reinstall:
 	pip uninstall -y codecov


### PR DESCRIPTION
The `make deploy` command fails with errors regarding `shell` not being a thing.

These changes adjust the commands in the makefile so deployment is possible again.

Updated the deploy command to use twine as recommended by the pypi docs.