### PR TITLE
Fix missed single quotes in gcov command

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -688,7 +688,7 @@ def main(*argv, **kwargs):
             write('==> Processing gcov (disable by -X gcov)')
             cmd = ['find',
                    (sanitize_arg('', codecov.gcov_root or root)), dont_search_here,
-                   '-type', 'f', '-name', '*.gcno', " ".join(map(lambda a: "-not -path '%s'" %
+                   '-type', 'f', '-name', '\'*.gcno\'', " ".join(map(lambda a: "-not -path '%s'" %
                                                                  a, codecov.gcov_glob)),
                    '-exec', (sanitize_arg('',
                                           codecov.gcov_exec or '')),


### PR DESCRIPTION
Missed single quotes around *.gcno pattern lead to next error:

```
Executing gcov (['find', 'EXAMPLE_PATH', "-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**'", '-type', 'f', '-name', '*.gcno', '', '-exec', 'gcov', '-pb', '', '{}', '+'])
Error running `['find', 'EXAMPLE_PATH', "-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**'", '-type', 'f', '-name', '*.gcno', '', '-exec', 'gcov', '-pb', '', '{}', '+']`: Command '['find', 'EXAMPLE_PATH', "-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**'", '-type', 'f', '-name', '*.gcno', '', '-exec', 'gcov', '-pb', '', '{}', '+']' returned non-zero exit status 1
```

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>