### PR TITLE
Removing extra url header

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -1046,7 +1046,6 @@ def main(*argv, **kwargs):
                                 data=reports,
                                 headers={
                                     "Content-Type": "text/plain",
-                                    "x-amz-acl": "public-read",
                                 },
                             )
                             s3.raise_for_status()


### PR DESCRIPTION
Now that we have pre-signed puts, we don't need to use presigned headers.

In fact, since they are added post-signing, the system is not responding well to them