### PR TITLE
[Master] Removing extra url header

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -1044,10 +1044,7 @@ def main(*argv, **kwargs):
                             s3 = requests.put(
                                 upload_url,
                                 data=reports,
-                                headers={
-                                    "Content-Type": "text/plain",
-                                    "x-amz-acl": "public-read",
-                                },
+                                headers={"Content-Type": "text/plain",},
                             )
                             s3.raise_for_status()
                             assert s3.status_code == 200

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-version = "2.0.21"
+version = "2.1.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",


### PR DESCRIPTION
Now that we have pre-signed puts, we don't need to use presigned headers.

In fact, since they are added post-signing, the system is not responding well to them