### PR TITLE
Fixing command for when neither hg or git are available

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -229,17 +229,15 @@ def _add_env_if_not_empty(lst, value):
 
 
 def generate_toc(root):
-    return (
-        str(
-            (
-                try_to_run(["git", "ls-files"], cwd=root)
-                or try_to_run(["git", "ls-files"])
-                or try_to_run(["hg", "locate"], cwd=root)
-                or try_to_run(["hg", "locate"])
-            )
-        ).strip()
-        or ""
+    res = (
+        try_to_run(["git", "ls-files"], cwd=root)
+        or try_to_run(["git", "ls-files"])
+        or try_to_run(["hg", "locate"], cwd=root)
+        or try_to_run(["hg", "locate"])
     )
+    if res is None:
+        return ""
+    return str(res).strip() or ""
 
 
 def main(*argv, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-version = "2.1.0"
+version = "2.1.1"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",


### PR DESCRIPTION
Sometimes not hg or git are available to run. On those cases, 'try_to_run' will return None, and we need to not stringify that None