### PR TITLE
Ignore emacs lisp files

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -88,6 +88,7 @@ ignored_report = re.compile(
     r"(/\.coverage.*)|"
     r"(\.coveragerc)|"
     r"(\.egg)|"
+    r"(\.el)|"
     r"(\.gif)|"
     r"(\.ini)|"
     r"(\.less)|"


### PR DESCRIPTION
Tahoe-LAFS project has a file named `/misc/coding_tools/coverage.el`, which is often uploaded to codecov along with the regular coverage report:  [here](https://app.circleci.com/pipelines/github/sajith/tahoe-lafs/350/workflows/2aade2f5-f5f9-4461-b272-ad3c972aca1e/jobs/4749/parallel-runs/0/steps/0-107) is an example.  

I'm not sure uploading some emacs lisp to codecov is doing any harm, but can't be doing anything useful either!  I will try to fix the CI setup, but it would be also nice if codecov would ignore `.el` files.