### PR TITLE
Fix error try_to_run using | without shell=True (fix #284)

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -869,7 +869,7 @@ def main(*argv, **kwargs):
             try:
                 query["commit"] = try_to_run(
                     ["git", "rev-parse", "HEAD"]
-                ) or try_to_run(["hg", "id", "-i", "--debug", "|", "tr", "-d", "'+'"])
+                ) or try_to_run(["hg", "log", "-r", ".", "-T", "{node}"])
                 write("  -> Got sha from git/hg")
 
             except:  # pragma: no cover


### PR DESCRIPTION
With `['hg', 'log', '-r', '.', '-T', '{node}']` to avoid `shell=True`.

Should fix #284