### PR TITLE
Added option to disable printing of gcov-out

### DIFF
--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -376,6 +376,9 @@ def main(*argv, **kwargs):
     gcov.add_argument(
         "--gcov-exec", default="gcov", help="gcov executable to run. Defaults to 'gcov'"
     )
+    gcov.add_argument(
+        "--no-gcov-out", action="store_true", default=False, help="Disable gcov output"
+    )
     gcov.add_argument("--gcov-args", default="", help="extra arguments to pass to gcov")
 
     advanced = parser.add_argument_group(
@@ -982,8 +985,11 @@ def main(*argv, **kwargs):
                 if codecov.gcov_args:
                     cmd.append(sanitize_arg("", codecov.gcov_args or ""))
                 cmd.append(path)
-                write("    Executing gcov (%s)" % cmd)
-                write(try_to_run(cmd))
+                if not codecov.no_gcov_out:
+                    write("    Executing gcov (%s)" % cmd)
+                gcov_out = try_to_run(cmd)
+                if not codecov.no_gcov_out:
+                    write(gcov_out)
 
         # Collect Reports
         # ---------------


### PR DESCRIPTION
This is similar to the same option by the same name in the bash uploader. Any errors written out to `stderr` by `gcov` will still be output in the `Popen` call. This PR should also help with #168. 