### PR TITLE
Add Cirrus CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ after_success:
 
 
 ## CI Providers
-|                       Company                       |                                                                                     Supported                                                                                      |  Token Required  |
+|                       Company                         |                                                                                     Supported                                                                                      |  Token Required  |
 | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | [AppVeyor](https://www.appveyor.com/)                 | Yes [![Build status](https://ci.appveyor.com/api/projects/status/sw18lsj7786bw806/branch/master?svg=true)](https://ci.appveyor.com/project/stevepeak/codecov-python/branch/master) | Private only     |
 | [Bamboo](https://www.atlassian.com/software/bamboo)   | `coming soon`                                                                                                                                                                      |                  |
@@ -96,6 +96,7 @@ after_success:
 | [Solano Labs](https://www.solanolabs.com/)            | `coming soon`                                                                                                                                                                      |                  |
 | [Travis CI](https://travis-ci.org/)                   | Yes [![Build Status](https://secure.travis-ci.org/codecov/codecov-python.svg?branch=master)](https://travis-ci.org/codecov/codecov-python)                                         | Private only     |
 | [Wercker](http://wercker.com/)                        | Yes                                                                                                                                                                                | Public & Private |
+| [Cirrus CI](https://cirrus-ci.org/)                   | Yes                                                                                                                                                                                | Private only     |
 | Git / Mercurial                                       | Yes (as a fallback)                                                                                                                                                                | Public & Private |
 
 

--- a/codecov/__init__.py
+++ b/codecov/__init__.py
@@ -329,7 +329,7 @@ def main(*argv, **kwargs):
         "--token",
         "-t",
         default=os.getenv("CODECOV_TOKEN"),
-        help="Private repository token or @filename for file containing the token. Defaults to $CODECOV_TOKEN. Not required for public repositories on Travis CI, CircleCI and AppVeyor",
+        help="Private repository token or @filename for file containing the token. Defaults to $CODECOV_TOKEN. Not required for public repositories on Travis CI, CircleCI, AppVeyor and CirrusCI",
     )
     basics.add_argument(
         "--file",
@@ -844,6 +844,25 @@ def main(*argv, **kwargs):
                 query["branch"] = os.getenv("GITHUB_HEAD_REF")
 
             write("    GitHub Actions CI Detected")
+
+        # ---------
+        # Cirrus CI
+        # ---------
+        elif os.getenv("CIRRUS_CI"):
+            # https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+            query.update(
+                dict(
+                    service="cirrus-ci",
+                    slug=os.getenv("CIRRUS_REPO_FULL_NAME"),
+                    branch=os.getenv("CIRRUS_BRANCH"),
+                    pr=os.getenv("CIRRUS_PR"),
+                    commit=os.getenv("CIRRUS_CHANGE_IN_REPO"),
+                    build=os.getenv("CIRRUS_BUILD_ID"),
+                    build_url="https://cirrus-ci.com/task/" + os.getenv("CIRRUS_TASK_ID"),
+                    job=os.getenv("CIRRUS_TASK_NAME"),
+                )
+            )
+            write("    Cirrus CI Detected")
 
         else:
             query.update(


### PR DESCRIPTION
Hello, this is a follow up of the discussion in:

https://community.codecov.com/t/add-support-of-uploading-from-cirrus-ci-without-token/1028/34

and uses the bash uploader as a reference:

https://github.com/codecov/codecov-bash/blob/master/codecov#L959